### PR TITLE
feat: SingleCellAgent REPL helper + guide-conformant dispatcher wiring

### DIFF
--- a/pantheon_cli/cli/prompt/single_cell_agent.py
+++ b/pantheon_cli/cli/prompt/single_cell_agent.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+
+
+def generate_single_cell_workflow_message(workflow_type: str) -> str:
+    """Generate SingleCellAgent workflow message using omicverse with persistent-state rules and templates"""
+    message = f"""
+🧬 Single-Cell Analysis Pipeline with OmicVerse Integration
+
+🔧 AVAILABLE WORKFLOW TOOLS:
+You have access to the SingleCellAgent_Templates tool for getting official templates.
+💡 Use the tool when you need guidance, official examples, or best practices for a specific workflow step.
+Ask for dataset path if unknown, use ls to inspect folders, then proceed with file loading.
+
+⚠️ CRITICAL PYTHON ENVIRONMENT RULES:
+- PERSISTENT STATE: Python interpreter maintains ALL variables across calls!
+- MEMORY OPTIMIZATION: Variables persist! NEVER re-read or re-import data that already exists in memory!
+- SMART VARIABLE CHECKING: Use try/except or 'var' in globals() to check existence — NO redundant I/O!
+- EFFICIENCY FIRST:
+  - Check if adata exists before loading: if 'adata' not in globals()
+  - Use existing results: if 'X_pca' in adata.obsm
+  - Reuse computed values: if 'marker_genes' in locals()
+- ERROR RECOVERY: If code fails, analyze error and fix — don't reload everything!
+- NO REPETITION: Each import/load/compute happens ONCE per session unless needed
+- After each step: mark_task_done("description"), then show_todos()
+- AUTOMATIC EXECUTION: Proceed automatically without confirmations; log warnings when needed.
+
+PHASE 0 — SETUP & VALIDATION
+1) Data discovery: Ask for path or use ls to inspect, then load an .h5ad dataset
+2) Environment checks happen during data loading
+
+PHASE 1 — TODO CREATION (ONCE ONLY)
+Execute: current = show_todos()
+IF current is EMPTY, create these todos ONCE:
+1. "Check Python environment and load initial data"
+2. "Run qc workflow"
+3. "Run annotation workflow"
+4. "Run trajectory workflow"
+5. "Run differential workflow"
+6. "Run visualization workflow"
+7. "Run clustering workflow"
+8. "Run batch_integration workflow"
+
+⚡ AUTOMATIC WORKFLOW MODE:
+- Execute each todo automatically; after success, mark_task_done() and proceed to next
+
+PHASE 2 — INTELLIGENT EXECUTION STRATEGY
+🧠 SMART DECISION MAKING:
+
+ASSESS:
+- What data is loaded? What results are available?
+- What guidance is needed?
+
+CHOOSE YOUR APPROACH:
+
+Option A — Use Template Tool (Recommended):
+- Call SingleCellAgent_Templates(workflow_type="<type>") to get official templates
+- Study returned guidance and patterns
+- Adapt template to your data
+- Execute adapted code
+
+Option B — Direct Implementation (Experienced users):
+- Write and run code based on omicverse/scanpy docs
+- Use help() to verify parameters
+- Follow best practices
+
+WHEN TO USE TEMPLATES:
+✅ Need official guidance or best practices
+✅ Unsure about parameters
+✅ Want standardized patterns
+
+RESULT ANALYSIS REQUIREMENT:
+1. Analyze outputs (numbers, plots, warnings)
+2. Interpret results
+3. Check for issues
+4. Adjust parameters if needed
+5. Document key insights to results dir
+6. Proceed based on findings
+
+The returned content serves as GUIDANCE and TEMPLATES, not execution scripts.
+
+🏷️ STEP EXAMPLES:
+
+— annotation —
+Use: SingleCellAgent_Templates(workflow_type="annotation")
+Then adapt to your data and execute.
+
+— trajectory —
+Use: SingleCellAgent_Templates(workflow_type="trajectory")
+
+— differential —
+Use: SingleCellAgent_Templates(workflow_type="differential")
+
+— visualization —
+Use: SingleCellAgent_Templates(workflow_type="visualization")
+
+— qc —
+Use: SingleCellAgent_Templates(workflow_type="qc")
+
+— clustering —
+Use: SingleCellAgent_Templates(workflow_type="clustering")
+
+— batch_integration —
+Use: SingleCellAgent_Templates(workflow_type="batch_integration")
+
+— communication | grn | drug | metacell —
+Use the corresponding workflow_type with SingleCellAgent_Templates
+
+"""
+
+    return message
+

--- a/pantheon_cli/cli/prompt/single_cell_agent.py
+++ b/pantheon_cli/cli/prompt/single_cell_agent.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 
 def generate_single_cell_workflow_message(workflow_type: str) -> str:
-    """Generate SingleCellAgent workflow message using omicverse with persistent-state rules and templates"""
+    """Generate SingleCellAgent workflow message with persistent-state rules and templates"""
     message = f"""
-🧬 Single-Cell Analysis Pipeline with OmicVerse Integration
+🧬 Single-Cell Analysis Pipeline
 
 🔧 AVAILABLE WORKFLOW TOOLS:
-You have access to the SingleCellAgent_Templates tool for getting official templates.
+You have access to the SingleCellAgent_Analysis tool for getting official templates.
 💡 Use the tool when you need guidance, official examples, or best practices for a specific workflow step.
 Ask for dataset path if unknown, use ls to inspect folders, then proceed with file loading.
 
@@ -53,13 +53,13 @@ ASSESS:
 CHOOSE YOUR APPROACH:
 
 Option A — Use Template Tool (Recommended):
-- Call SingleCellAgent_Templates(workflow_type="<type>") to get official templates
+- Call SingleCellAgent_Analysis(workflow_type="<type>") to get official templates
 - Study returned guidance and patterns
 - Adapt template to your data
 - Execute adapted code
 
 Option B — Direct Implementation (Experienced users):
-- Write and run code based on omicverse/scanpy docs
+- Write and run code based on your preferred toolkit's docs
 - Use help() to verify parameters
 - Follow best practices
 
@@ -81,31 +81,30 @@ The returned content serves as GUIDANCE and TEMPLATES, not execution scripts.
 🏷️ STEP EXAMPLES:
 
 — annotation —
-Use: SingleCellAgent_Templates(workflow_type="annotation")
+Use: SingleCellAgent_Analysis(workflow_type="annotation")
 Then adapt to your data and execute.
 
 — trajectory —
-Use: SingleCellAgent_Templates(workflow_type="trajectory")
+Use: SingleCellAgent_Analysis(workflow_type="trajectory")
 
 — differential —
-Use: SingleCellAgent_Templates(workflow_type="differential")
+Use: SingleCellAgent_Analysis(workflow_type="differential")
 
 — visualization —
-Use: SingleCellAgent_Templates(workflow_type="visualization")
+Use: SingleCellAgent_Analysis(workflow_type="visualization")
 
 — qc —
-Use: SingleCellAgent_Templates(workflow_type="qc")
+Use: SingleCellAgent_Analysis(workflow_type="qc")
 
 — clustering —
-Use: SingleCellAgent_Templates(workflow_type="clustering")
+Use: SingleCellAgent_Analysis(workflow_type="clustering")
 
 — batch_integration —
-Use: SingleCellAgent_Templates(workflow_type="batch_integration")
+Use: SingleCellAgent_Analysis(workflow_type="batch_integration")
 
 — communication | grn | drug | metacell —
-Use the corresponding workflow_type with SingleCellAgent_Templates
+Use the corresponding workflow_type with SingleCellAgent_Analysis
 
 """
 
     return message
-

--- a/pantheon_cli/repl/bio_handler.py
+++ b/pantheon_cli/repl/bio_handler.py
@@ -52,6 +52,8 @@ class BioCommandHandler:
         self.console.print("[dim]  /bio rna upstream ./data      # Run RNA-seq upstream analysis[/dim]")
         self.console.print("[dim]  /bio spatial init              # Initialize spatial project[/dim]")
         self.console.print("[dim]  /bio spatial run_spatial_workflow <workflow_type> # Run spatial workflow[/dim]")
+        self.console.print("[dim]  /bio singlecell init           # Initialize single-cell analysis mode[/dim]")
+        self.console.print("[dim]  /bio singlecell run_singlecell_workflow <analysis_type> # Run single-cell workflow[/dim]")
         self.console.print("[dim]  /bio dock init                # Initialize molecular docking project[/dim]")
         self.console.print("[dim]  /bio dock run_dock            # Interactive molecular docking workflow[/dim]")
         self.console.print("[dim]  /bio dock run ./data          # Run batch molecular docking on folder[/dim]")
@@ -104,6 +106,9 @@ class BioCommandHandler:
         
         if tool_name == "spatial":
             return self._handle_spatial_command(parts)
+        
+        if tool_name in ["singlecell", "single_cell", "single_cell_agent", "SingleCellAgent"]:
+            return self._handle_singlecell_command(parts)
         
         # Generic handler for other tools
         if len(parts) > 2:
@@ -190,6 +195,69 @@ Response format (single line):
             self.console.print("[dim]Sending spatial workflow request...[/dim]\n")
             
             return spatial_message
+
+    def _handle_singlecell_command(self, parts) -> str:
+        """Handle single-cell-specific commands with special logic"""
+        if len(parts) == 2:
+            # Just /bio singlecell - show help
+            self.console.print("\n[bold]🧬 Single-Cell Analysis Helper[/bold]")
+            self.console.print("[dim]/bio singlecell init[/dim] - Initialize single-cell analysis mode")
+            self.console.print("[dim]/bio singlecell run_singlecell_workflow <analysis_type>[/dim] - Run single-cell workflow")
+            self.console.print("\n[dim]Examples:[/dim]")
+            self.console.print("[dim]  /bio singlecell init                                # Initialize single-cell mode[/dim]")
+            self.console.print("[dim]  /bio singlecell run_singlecell_workflow annotation  # Run annotation workflow[/dim]")
+            self.console.print()
+            return None
+
+        command = parts[2]
+
+        if command == "init":
+            self.console.print("\n[bold cyan]🧬 Initializing single-cell analysis project[/bold cyan]")
+            clear_message = """
+singlecell INIT MODE — STRICT
+
+Goal: ONLY clear TodoList and report the new status. Do NOT create or execute anything.
+
+Allowed tools (whitelist):
+  - clear_all_todos()
+  - show_todos()
+
+Hard bans (do NOT call under any circumstance in init):
+  - add_todo(), mark_task_done(), execute_current_task()
+  - any single cell analysis tools
+
+Steps:
+  1) clear_all_todos()
+  2) todos = show_todos()
+
+Response format (single line):
+  singlecell init ready • todos={len(todos)}
+            """
+            self.console.print("[dim]Clearing existing todos and preparing single-cell environment...[/dim]")
+            self.console.print("[dim]Ready for single-cell analysis assistance...[/dim]")
+            self.console.print("[dim]Single-cell mode activated. You can now use single-cell tools directly.[/dim]")
+            self.console.print()
+            self.console.print("[dim]The command structure is now:[/dim]")
+            self.console.print("[dim]  - /bio singlecell init - Enter single-cell mode[/dim]")
+            self.console.print("[dim]  - /bio singlecell run_singlecell_workflow <analysis_type> - Run single-cell workflow[/dim]")
+            self.console.print()
+            return clear_message
+
+        elif command == "run_singlecell_workflow":
+            if len(parts) < 4:
+                self.console.print("[red]Error: Please specify an analysis_type[/red]")
+                self.console.print("[dim]Usage: /bio singlecell run_singlecell_workflow <analysis_type>[/dim]")
+                self.console.print("[dim]Example: /bio singlecell run_singlecell_workflow annotation[/dim]")
+                return None
+
+            analysis_type = parts[3]
+            self.console.print(f"\n[bold cyan]🧬 Starting single-cell workflow: {analysis_type}[/bold cyan]")
+            self.console.print("[dim]Preparing single-cell analysis pipeline...[/dim]\n")
+
+            from ..cli.prompt.single_cell_agent import generate_single_cell_workflow_message
+            sc_message = generate_single_cell_workflow_message(workflow_type=analysis_type)
+            self.console.print("[dim]Sending single-cell workflow request...[/dim]\n")
+            return sc_message
             
     
     def _handle_atac_command(self, parts) -> str:

--- a/pantheon_cli/repl/ui.py
+++ b/pantheon_cli/repl/ui.py
@@ -968,6 +968,18 @@ class ReplUI:
             
             self.console.print("╰" + "─" * 77 + "╯")
             
+        elif tool_name == "SingleCellAgent" and args and 'analysis_type' in args:
+            # Special handling for SingleCellAgent calls
+            analysis_type = args['analysis_type']
+            icon = "🧬"
+            workflow_title = f"Single-Cell Analysis: {analysis_type}"
+            self.console.print(f"⏺ [bold]{icon} {tool_name}[/bold]")
+
+            self.console.print("╭" + "─" * 77 + "╮")
+            title_padding = " " * (77 - len(workflow_title) - 4)
+            self.console.print(f"│ [bold cyan]{workflow_title}[/bold cyan]{title_padding}   │")
+            self.console.print("╰" + "─" * 77 + "╯")
+
         else:
             # Generic tool call
             if args:


### PR DESCRIPTION
This PR adds a REPL helper and prompt for SingleCellAgent that follow the Biology Toolsets guide, and aligns CLI messaging to the new dispatcher in pantheon-toolsets.

Changes
- CLI prompt: `pantheon_cli/cli/prompt/single_cell_agent.py`
  - Backend-agnostic wording (no vendor mentions)
  - Instructs to use `SingleCellAgent_Analysis(workflow_type=...)` dispatcher that returns guidance/templates
  - Persistent-state rules and todo-driven workflow like spatial example
- REPL bio handler: existing routing to single-cell prompt remains; no breaking changes

Why
- The initial SingleCellAgent UX was built before following the guide. This implements the dispatcher-style UX on the CLI side to match the updated toolset.

Usage
- `/bio singlecell init`
- `/bio singlecell run_singlecell_workflow annotation` (or qc, trajectory, differential, visualization, clustering, batch_integration, communication, grn, drug, metacell)
- The prompt will guide calling `SingleCellAgent_Analysis(workflow_type="<type>")` and using the returned templates.

Notes
- Messaging is backend-agnostic while retaining internal preference.
- Complements the pantheon-toolsets PR introducing `SingleCellAgent_Analysis`.
