### PR TITLE
Add CLI controls for reasoning effort

### DIFF
--- a/pantheon_cli/cli/manager/api_key_manager.py
+++ b/pantheon_cli/cli/manager/api_key_manager.py
@@ -522,7 +522,13 @@ class APIKeyManager:
             
             if self.save_api_key(provider_key, api_key, save_global=save_global):
                 location = "globally" if save_global else "locally"
-                return f"✅ {PROVIDER_NAMES[provider_key]} API key saved {location} and set successfully!"
+                message = f"✅ {PROVIDER_NAMES[provider_key]} API key saved {location} and set successfully!"
+                if provider_key == "OPENAI_API_KEY":
+                    message += (
+                        "\n🧠 Planning to use GPT-5 or OpenAI o-series reasoning models? "
+                        "Choose the effort level with `/reasoning effort <minimal|low|medium|high>` before your next task."
+                    )
+                return message
             else:
                 return f"❌ Failed to save {PROVIDER_NAMES[provider_key]} API key. Check file permissions."
         else:

--- a/pantheon_cli/repl/core.py
+++ b/pantheon_cli/repl/core.py
@@ -668,6 +668,10 @@ class Repl(ReplUI):
                 self._handle_model_command(current_message.strip())
                 current_message = None  # Reset to get new input
                 continue
+            elif current_message.strip().startswith("/reasoning"):
+                self._handle_reasoning_command(current_message.strip())
+                current_message = None
+                continue
             elif current_message.strip().startswith("/api-key"):
                 self._handle_api_key_command(current_message.strip())
                 current_message = None  # Reset to get new input
@@ -882,6 +886,18 @@ class Repl(ReplUI):
         except Exception as e:
             self.console.print(f"[red]Error handling model command: {str(e)}[/red]")
         self.console.print()  # Add spacing
+
+    def _handle_reasoning_command(self, command: str):
+        """Handle /reasoning commands in REPL"""
+        try:
+            if hasattr(self.agent, '_model_manager') and self.agent._model_manager:
+                result = self.agent._model_manager.handle_reasoning_command(command)
+                self.console.print(result)
+            else:
+                self.console.print("[red]Reasoning manager not available. Please restart with the CLI.[/red]")
+        except Exception as e:
+            self.console.print(f"[red]Error handling reasoning command: {str(e)}[/red]")
+        self.console.print()
 
     def _handle_api_key_command(self, command: str):
         """Handle /api-key commands in REPL"""


### PR DESCRIPTION
## Summary
- add reasoning-effort persistence and level gating per model
- expose /reasoning command in the REPL and surface supported levels in status outputs
- remind users about effort levels after setting an OpenAI key

## Testing
- python -m compileall pantheon_cli/cli/manager/model_manager.py
